### PR TITLE
product CRUD에 대한 코드 리뷰 반영

### DIFF
--- a/src/controllers/productController.ts
+++ b/src/controllers/productController.ts
@@ -21,14 +21,14 @@ export async function createProduct(
 export async function getProductList(req: Request, res: Response) {
   const data = await productService.getProductList();
 
-  res.status(200).json(data);
+  res.status(200).json(data.map((product) => new ProductResponseDto(product)));
 }
 
 export async function getProduct(req: Request, res: Response) {
   const { id } = create(req.params, IdParamsStruct);
   const product = await productService.getProduct(id);
 
-  res.status(200).json(product);
+  res.status(200).json(new ProductResponseDto(product));
 }
 
 export async function updateProduct(req: Request, res: Response) {
@@ -43,5 +43,5 @@ export async function deleteProduct(req: Request, res: Response) {
   const { id } = create(req.params, IdParamsStruct);
   await productService.deleteProduct(id);
 
-  res.status(204).json();
+  res.status(204).send();
 }

--- a/src/repositories/productRepository.ts
+++ b/src/repositories/productRepository.ts
@@ -1,13 +1,14 @@
+import { Product } from "@prisma/client";
 import { prisma } from "../lib/prisma";
 import { CreateProductType, UpdateProductType } from "../structs/productStruct";
 
-export async function createProduct(data: CreateProductType) {
-  return await prisma.product.create({
+export async function createProduct(data: CreateProductType): Promise<Product> {
+  return prisma.product.create({
     data,
   });
 }
 
-export async function getProductList() {
+export async function getProductList(): Promise<Product[]> {
   return await prisma.product.findMany({
     orderBy: {
       createdAt: "desc",
@@ -15,21 +16,24 @@ export async function getProductList() {
   });
 }
 
-export async function getProduct(id: number) {
+export async function getProduct(id: number): Promise<Product | null> {
   return await prisma.product.findUnique({
     where: { id },
   });
 }
 
-export async function updateProduct(id: number, data: UpdateProductType) {
+export async function updateProduct(
+  id: number,
+  data: UpdateProductType
+): Promise<Product> {
   return await prisma.product.update({
     where: { id },
     data,
   });
 }
 
-export async function deleteProduct(id: number) {
-  return await prisma.product.delete({
+export async function deleteProduct(id: number): Promise<void> {
+  await prisma.product.delete({
     where: { id },
   });
 }

--- a/src/repositories/productRepository.ts
+++ b/src/repositories/productRepository.ts
@@ -9,7 +9,7 @@ export async function createProduct(data: CreateProductType): Promise<Product> {
 }
 
 export async function getProductList(): Promise<Product[]> {
-  return await prisma.product.findMany({
+  return prisma.product.findMany({
     orderBy: {
       createdAt: "desc",
     },
@@ -17,7 +17,7 @@ export async function getProductList(): Promise<Product[]> {
 }
 
 export async function getProduct(id: number): Promise<Product | null> {
-  return await prisma.product.findUnique({
+  return prisma.product.findUnique({
     where: { id },
   });
 }
@@ -26,7 +26,7 @@ export async function updateProduct(
   id: number,
   data: UpdateProductType
 ): Promise<Product> {
-  return await prisma.product.update({
+  return prisma.product.update({
     where: { id },
     data,
   });

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -1,17 +1,17 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, Product } from "@prisma/client";
 import NotFoundError from "../lib/errors/NotFoundError";
 import * as productRepository from "../repositories/productRepository";
 import { CreateProductType, UpdateProductType } from "../structs/productStruct";
 
-export async function createProduct(data: CreateProductType) {
+export async function createProduct(data: CreateProductType): Promise<Product> {
   return await productRepository.createProduct(data);
 }
 
-export async function getProductList() {
+export async function getProductList(): Promise<Product[]> {
   return await productRepository.getProductList();
 }
 
-export async function getProduct(id: number) {
+export async function getProduct(id: number): Promise<Product> {
   const product = await productRepository.getProduct(id);
   if (!product) {
     throw new NotFoundError("Product not found");
@@ -20,7 +20,10 @@ export async function getProduct(id: number) {
   return product;
 }
 
-export async function updateProduct(id: number, data: UpdateProductType) {
+export async function updateProduct(
+  id: number,
+  data: UpdateProductType
+): Promise<Product> {
   try {
     return await productRepository.updateProduct(id, data);
   } catch (error) {
@@ -34,7 +37,7 @@ export async function updateProduct(id: number, data: UpdateProductType) {
   }
 }
 
-export async function deleteProduct(id: number) {
+export async function deleteProduct(id: number): Promise<void> {
   try {
     return await productRepository.deleteProduct(id);
   } catch (error) {

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import NotFoundError from "../lib/errors/NotFoundError";
 import * as productRepository from "../repositories/productRepository";
 import { CreateProductType, UpdateProductType } from "../structs/productStruct";
@@ -13,26 +14,36 @@ export async function getProductList() {
 export async function getProduct(id: number) {
   const product = await productRepository.getProduct(id);
   if (!product) {
-    throw new NotFoundError("This dose not exist");
+    throw new NotFoundError("Product not found");
   }
 
   return product;
 }
 
 export async function updateProduct(id: number, data: UpdateProductType) {
-  const product = await productRepository.getProduct(id);
-  if (!product) {
-    throw new NotFoundError("This dose not exist");
+  try {
+    return await productRepository.updateProduct(id, data);
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      throw new NotFoundError("Product not found");
+    }
+    throw error;
   }
-
-  return await productRepository.updateProduct(id, data);
 }
 
 export async function deleteProduct(id: number) {
-  const product = await productRepository.getProduct(id);
-  if (!product) {
-    throw new NotFoundError("This dose not exist");
+  try {
+    return await productRepository.deleteProduct(id);
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      throw new NotFoundError("Product not found");
+    }
+    throw error;
   }
-
-  return await productRepository.deleteProduct(id);
 }

--- a/src/structs/productStruct.ts
+++ b/src/structs/productStruct.ts
@@ -10,7 +10,7 @@ import {
 } from "superstruct";
 
 export const createProductBodyStruct = object({
-  name: nonempty(nonempty(string())),
+  name: nonempty(string()),
   description: nonempty(string()),
   price: min(integer(), 0),
   tags: array(nonempty(string())),


### PR DESCRIPTION
코드 리뷰 반영으로 아래와 같이 개선
컨트롤러 계층에서 응답 형식을 일관되게 관리하기 위해 ProductResponseDto를 도입 update 및 delete 서비스 로직에서 Prisma의 P2025 에러를 직접 처리하도록 변경하여, 불필요한 getProduct 호출을 제거하고 코드를 단순화 레포지토리 함수의 반환 타입을 명시하여 타입 안정성을 강화
deleteProduct 컨트롤러가 204 응답에 body를 보내지 않도록 .send()를 사용하도록 수정 상품 생성 유효성 검사에서 중복된 nonempty를 제거